### PR TITLE
Close Files opened streams to prevent resource leakage

### DIFF
--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerArchiver.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerArchiver.java
@@ -21,6 +21,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,8 +37,8 @@ class ContinuousAsyncProfilerArchiver implements Runnable {
         Path continuousDir = Paths.get(properties.getContinuousOutputDir());
         BiPredicate<Path, BasicFileAttributes> predicate = (p, basicFileAttributes) -> p.getFileName().toString().matches(properties.getArchiveCopyRegex());
         while (!Thread.interrupted()) {
-            try {
-                Files.find(continuousDir, 1, predicate)
+            try (Stream<Path> archiveStream = Files.find(continuousDir, 1, predicate)) {
+                archiveStream
                         .forEach(sourcePath -> {
                             String fileName = sourcePath.getFileName().toString();
                             String destinationFileName = properties.getArchiveOutputDir() + "/" + fileName;

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCleaner.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCleaner.java
@@ -17,7 +17,10 @@ package com.github.krzysztofslusarski.asyncprofiler;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,8 +50,8 @@ class ContinuousAsyncProfilerCleaner implements Runnable {
     }
 
     public void delete(String cleanDir, long cutOffTime) {
-        try {
-            Files.list(Paths.get(cleanDir))
+        try (Stream<Path> list = Files.list(Paths.get(cleanDir))) {
+            list
                     .filter(path -> {
                         try {
                             return Files.isRegularFile(path) && Files.getLastModifiedTime(path).toMillis() < cutOffTime;

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCompressor.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCompressor.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,8 +53,8 @@ class ContinuousAsyncProfilerCompressor implements Runnable {
         };
 
         while (!Thread.interrupted()) {
-            try {
-                List<Path> notCompressedFiles = Files.find(continuousDir, 1, predicate)
+            try (Stream<Path> pathStream = Files.find(continuousDir, 1, predicate)) {
+                List<Path> notCompressedFiles = pathStream
                         .sorted(pathComparator)
                         .collect(Collectors.toList());
                 int counter = notCompressedFiles.size() - 2;


### PR DESCRIPTION
as documentation says:
> This method must be used within a try-with-resources statement or similar control structure to ensure that the stream's open directories are closed promptly after the stream's operations have completed

we need to close `Files` related `streams`