### PR TITLE
"java.nio.Files#delete" should be preferred

### DIFF
--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCompressor.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCompressor.java
@@ -63,7 +63,7 @@ class ContinuousAsyncProfilerCompressor implements Runnable {
                     }
                     Path target = Paths.get(source.toAbsolutePath().toString() + ".gz");
                     compressGzip(source, target);
-                    source.toFile().delete();
+                    Files.delete(source);
                     counter--;
                 }
 


### PR DESCRIPTION
When java.io.File#delete fails, this boolean method simply returns
false with no indication of the cause. On the other hand, when
java.nio.file.Files#delete fails, this void method returns one of a
series of exception types to better indicate the cause of the
failure. And since more information is generally better in a
debugging situation, java.nio.file.Files#delete is the preferred
option.

Copy-pasted from sonar scan. If you've made that intentionally pls
let me know.