### PR TITLE
"InterruptedException" should not be ignored

### DIFF
--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerArchiver.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerArchiver.java
@@ -55,6 +55,7 @@ class ContinuousAsyncProfilerArchiver implements Runnable {
                 Thread.sleep(SleepTime.ONE_DAY);
             } catch (InterruptedException e) {
                 log.info("Thread interrupted, exiting", e);
+                Thread.currentThread().interrupt();
                 return;
             } catch (IOException e) {
                 log.error("Cannot list dir: " + properties.getContinuousOutputDir(), e);

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCleaner.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCleaner.java
@@ -41,6 +41,7 @@ class ContinuousAsyncProfilerCleaner implements Runnable {
                 Thread.sleep(SleepTime.ONE_HOUR);
             } catch (InterruptedException e) {
                 log.info("Thread interrupted, exiting", e);
+                Thread.currentThread().interrupt();
                 return;
             }
         }

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCompressor.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerCompressor.java
@@ -70,6 +70,7 @@ class ContinuousAsyncProfilerCompressor implements Runnable {
                 Thread.sleep(SleepTime.TEN_MINUTES);
             } catch (InterruptedException e) {
                 log.info("Thread interrupted, exiting", e);
+                Thread.currentThread().interrupt();
                 return;
             } catch (IOException e) {
                 log.error("Some IO failed", e);

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerRunner.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerRunner.java
@@ -55,6 +55,7 @@ class ContinuousAsyncProfilerRunner implements Runnable {
                 log.error("Cannot run profiler", e);
             } catch (InterruptedException e) {
                 log.info("Thread interrupted, exiting", e);
+                Thread.currentThread().interrupt();
                 return;
             } finally {
                 if (started) {


### PR DESCRIPTION
InterruptedExceptions should never be ignored in the code, and simply
logging the exception counts in this case as "ignoring". The throwing
of the InterruptedException clears the interrupted state of the Thread,
so if the exception is not handled properly the fact that the thread
was interrupted will be lost. Instead, InterruptedExceptions should
either be rethrown - immediately or after cleaning up the method's
state - or the thread should be re-interrupted by calling
Thread.interrupt() even if this is supposed to be a single-threaded
application. Any other course of action risks delaying thread shutdown
and loses the information that the thread was interrupted - probably
without finishing its task.

//based on sonar (copy pasted message)