### PR TITLE
URIs should not be hardcoded

### DIFF
--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerArchiver.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerArchiver.java
@@ -39,8 +39,7 @@ class ContinuousAsyncProfilerArchiver implements Runnable {
                 Files.find(continuousDir, 1, predicate)
                         .forEach(sourcePath -> {
                             String fileName = sourcePath.getFileName().toString();
-                            String destinationFileName = properties.getArchiveOutputDir() + "/" + fileName;
-                            Path destinationPath = Paths.get(destinationFileName);
+                            Path destinationPath = Paths.get(properties.getArchiveOutputDir(), fileName);
                             if (!destinationPath.toFile().exists()) {
                                 log.info("Archiving: {} to: {}", fileName, destinationPath.toAbsolutePath().toString());
                                 try {


### PR DESCRIPTION
Hard coding a URI makes it difficult to test a program: path literals
are not always portable across operating systems, a given absolute path
may not exist on a specific test environment, a specified Internet URL
may not be available when executing the tests, production environment
filesystems usually differ from the development environment, ...etc. For
 all those reasons, a URI should never be hard coded. Instead, it should
  be replaced by customizable parameter.

Further even if the elements of a URI are obtained dynamically,
portability can still be limited if the path-delimiters are hard-coded.

This rule raises an issue when URI's or path delimiters are hard coded.

//based on sonar (copy pasted message)