### PR TITLE
Magic Numbers

### DIFF
--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerProperties.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerProperties.java
@@ -31,4 +31,8 @@ class ContinuousAsyncProfilerProperties {
     int continuousOutputsMaxAgeHours;
     int archiveOutputsMaxAgeDays;
     String archiveCopyRegex;
+
+    long dumpIntervalMilliseconds() {
+        return dumpIntervalSeconds * 1000L;
+    }
 }

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerRunner.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerRunner.java
@@ -46,7 +46,7 @@ class ContinuousAsyncProfilerRunner implements Runnable {
                     params = createParams();
                     asyncProfiler.execute("start," + params);
                     started = true;
-                    Thread.sleep(properties.getDumpIntervalSeconds() * 1000);
+                    Thread.sleep(properties.dumpIntervalMilliseconds());
                     log.info("Stopping async-profiler");
                     asyncProfiler.execute("stop," + params);
                     started = false;

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/SleepTime.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/SleepTime.java
@@ -15,9 +15,14 @@
  */
 package com.github.krzysztofslusarski.asyncprofiler;
 
-interface SleepTime {
-    long ONE_MINUTE = 1000 * 60;
-    long TEN_MINUTES = ONE_MINUTE * 10;
-    long ONE_HOUR = 60 * ONE_MINUTE;
-    long ONE_DAY = ONE_HOUR * 24;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+final class SleepTime {
+    static final long ONE_MINUTE = 1000L * 60;
+    static final long TEN_MINUTES = ONE_MINUTE * 10;
+    static final long ONE_HOUR = 60 * ONE_MINUTE;
+    static final long ONE_DAY = ONE_HOUR * 24;
 }


### PR DESCRIPTION
Don't use implicit long casting. Properties should return preformatted
values. Constants should not be defined in interfaces.

According to Joshua Bloch, author of "Effective Java":

  The constant interface pattern is a poor use of interfaces.

  That a class uses some constants internally is an implementation
  detail.

  Implementing a constant interface causes this implementation detail to
  leak into the class's exported API. It is of no consequence to the
  users of a class that the class implements a constant interface. In
  fact, it may even confuse them. Worse, it represents a commitment: if
  in a future release the class is modified so that it no longer needs
  to use the constants, it still must implement the interface to ensure
  binary compatibility. If a nonfinal class implements a constant
  interface, all of its subclasses will have their namespaces polluted
  by the constants in the interface.

This rule raises an issue when an interface consists solely of fields,
without any other members.