### PR TITLE
Support ConfigurationProperties #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,17 @@ The async-profiler is run **all the time** in **wall-clock mode**. Output from t
 
 ## Configuration properties and defaults
 
-* ```asyncProfiler.continuous.enabled = true``` - if the tool should work or not
-* ```asyncProfiler.continuous.dumpIntervalSeconds = 60``` - time in seconds, how often tool should dump profiler outputs
-* ```asyncProfiler.continuous.continuousOutputsMaxAgeHours = 24``` - time in hours, how long to keep files in the continuous directory
-* ```asyncProfiler.continuous.archiveOutputsMaxAgeDays = 30``` - time in days, how long to keep files in the archive directory
-* ```asyncProfiler.continuous.archiveCopyRegex = .*_13:0.*``` - regex for file name, which files should be copied from the continuous to the archive directory
-* ```asyncProfiler.continuous.event = wall``` - async-profiler event to fetch
-* ```asyncProfiler.continuous.outputDir.continuous = logs/continuous``` - where continuous output should be stored
-* ```asyncProfiler.continuous.outputDir.archive = logs/archive``` - where archive of the outputs should be stored
-* ```asyncProfiler.continuous.stopWorkFile = profiler-stop``` - path to a file, if the file exists then profiler is not running, using this file you can turn
+* ```async-profiler.continuous.enabled = true``` - if the tool should work or not
+* ```async-profiler.continuous.dump-interval = 60``` - time in seconds, how often tool should dump profiler outputs
+* ```async-profiler.continuous.continuous-outputs-max-age-hours = 24``` - time in hours, how long to keep files in the continuous directory
+* ```async-profiler.continuous.archive-outputs-max-age-days = 30``` - time in days, how long to keep files in the archive directory
+* ```async-profiler.continuous.archive-copy-regex = .*_13:0.*``` - regex for file name, which files should be copied from the continuous to the archive directory
+* ```async-profiler.continuous.event = wall``` - async-profiler event to fetch
+* ```async-profiler.continuous.output-dir.continuous = logs/continuous``` - where continuous output should be stored
+* ```async-profiler.continuous.output-dir.archive = logs/archive``` - where archive of the outputs should be stored
+* ```async-profiler.continuous.stop-work-file = profiler-stop``` - path to a file, if the file exists then profiler is not running, using this file you can turn
 on/off profiling at runtime
-* ```asyncProfiler.continuous.profilerLibPath``` - path to ```libasyncProfiler.so```
+* ```asyncProfiler.continuous.profiler-lib-path``` - path to ```libasyncProfiler.so```
 
 ## Troubleshooting
 

--- a/continuous-async-profiler-spring-starter/pom.xml
+++ b/continuous-async-profiler-spring-starter/pom.xml
@@ -9,11 +9,27 @@
 
     <artifactId>continuous-async-profiler-spring-starter</artifactId>
 
+    <properties>
+        <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>continuous-async-profiler</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <version>${spring-boot.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/continuous-async-profiler-spring-starter/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerAutoConfiguration.java
+++ b/continuous-async-profiler-spring-starter/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Krzysztof Slusarski
+ * Copyright 2020 Krzysztof Slusarski, Michal Rowicki
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,16 @@
  */
 package com.github.krzysztofslusarski.asyncprofiler;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import(ContinuousAsyncProfilerConfiguration.class)
+@EnableConfigurationProperties(ContinuousAsyncProfilerBootProperties.class)
 public class ContinuousAsyncProfilerAutoConfiguration {
+
+    @Bean
+    ContinuousAsyncProfiler continuousAsyncProfiler(ContinuousAsyncProfilerBootProperties properties) {
+        return new ContinuousAsyncProfiler(properties.toSpringFrameworkProperties());
+    }
 }

--- a/continuous-async-profiler-spring-starter/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerBootProperties.java
+++ b/continuous-async-profiler-spring-starter/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerBootProperties.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Michal Rowicki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.krzysztofslusarski.asyncprofiler;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+@Data
+@ConfigurationProperties("async-profiler.continuous")
+class ContinuousAsyncProfilerBootProperties {
+    /**
+     * if the tool should work or not
+     */
+    private boolean enabled = true;
+    /**
+     * custom path to libasyncProfiler.so
+     */
+    private Path profilerLibPath;
+    /**
+     * async-profiler event to fetch
+     */
+    private String event = "wall";
+    /**
+     * path to a file, if the file exists then profiler is not running, using this file you can turn
+     * on/off profiling at runtime
+     */
+    private Path stopWorkFile = Paths.get("profiler-stop");
+
+    private OutputDir outputDir;
+
+    @Data
+    static class OutputDir {
+        /**
+         * where continuous output should be stored
+         */
+        private Path continuous = Paths.get("logs/continuous");
+        /**
+         * where archive of the outputs should be stored
+         */
+        private Path archive = Paths.get("logs/archive");
+    }
+
+    /**
+     * duration of how often tool should dump profiler outputs
+     */
+    private Duration dumpInterval = Duration.ofSeconds(60);
+    /**
+     * time in hours, how long to keep files in the continuous directory
+     */
+    private Duration continuousOutputsMaxAgeHours = Duration.ofHours(24);
+    /**
+     * time in days, how long to keep files in the archive directory
+     */
+    private Duration archiveOutputsMaxAgeDays = Duration.ofDays(30);
+    /**
+     * regex for file name, which files should be copied from the continuous to the archive directory
+     */
+    private Pattern archiveCopyRegex = Pattern.compile(".*_13:0.*");
+
+    public ContinuousAsyncProfilerProperties toSpringFrameworkProperties() {
+        return ContinuousAsyncProfilerProperties.builder()
+                .enabled(enabled)
+                .event(event)
+                .stopFile(stopWorkFile.toString())
+                .dumpIntervalSeconds((int) dumpInterval.getSeconds())
+                .continuousOutputsMaxAgeHours((int) continuousOutputsMaxAgeHours.toHours())
+                .archiveOutputsMaxAgeDays((int) archiveOutputsMaxAgeDays.toDays())
+                .archiveCopyRegex(archiveCopyRegex.pattern())
+                .continuousOutputDir(outputDir.continuous.toString())
+                .archiveOutputDir(outputDir.archive.toString())
+                .profilerLibPath(profilerLibPath.toString())
+                .build();
+    }
+}

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfiler.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfiler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Krzysztof Slusarski, Michal Rowicki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.krzysztofslusarski.asyncprofiler;
+
+import lombok.extern.slf4j.Slf4j;
+import one.profiler.AsyncProfiler;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.util.StringUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class ContinuousAsyncProfiler implements DisposableBean {
+
+    private final List<Thread> threads = new ArrayList<>();
+
+    public ContinuousAsyncProfiler(ContinuousAsyncProfilerProperties properties) {
+        log.info("Staring with configuration: {}", properties);
+
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        createOutputDirectories(properties);
+        AsyncProfiler asyncProfiler = StringUtils.isEmpty(properties.getProfilerLibPath()) ?
+                AsyncProfiler.getInstance() : AsyncProfiler.getInstance(properties.getProfilerLibPath());
+
+        threads.add(new Thread(new ContinuousAsyncProfilerRunner(asyncProfiler, properties), "cont-prof-runner"));
+        threads.add(new Thread(new ContinuousAsyncProfilerCleaner(properties), "cont-prof-cleaner"));
+        threads.add(new Thread(new ContinuousAsyncProfilerArchiver(properties), "cont-prof-arch"));
+        threads.add(new Thread(new ContinuousAsyncProfilerCompressor(properties), "cont-prof-gzip"));
+        log.info("Starting continuous profiling threads");
+        threads.forEach(Thread::start);
+    }
+
+    private void createOutputDirectories(ContinuousAsyncProfilerProperties properties) {
+        try {
+            log.debug("Checking if output dirs exist");
+            Files.createDirectories(Paths.get(properties.getArchiveOutputDir()));
+            Files.createDirectories(Paths.get(properties.getContinuousOutputDir()));
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create output dirs", e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        log.info("Spring context destroyed, shutting down threads");
+        threads.forEach(Thread::interrupt);
+    }
+}

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerConfiguration.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Krzysztof Slusarski
+ * Copyright 2020 Krzysztof Slusarski, Michal Rowicki
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,16 @@
  */
 package com.github.krzysztofslusarski.asyncprofiler;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
-import one.profiler.AsyncProfiler;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 @Configuration
 public class ContinuousAsyncProfilerConfiguration {
-    private final List<Thread> threads = new ArrayList<>();
+
+    private final ContinuousAsyncProfilerProperties properties;
 
     public ContinuousAsyncProfilerConfiguration(
             @Value("${asyncProfiler.continuous.enabled:true}") boolean enabled,
@@ -44,7 +38,7 @@ public class ContinuousAsyncProfilerConfiguration {
             @Value("${asyncProfiler.continuous.outputDir.archive:logs/archive}") String outputDirArchive,
             @Value("${asyncProfiler.continuous.outputDir.continuous:logs/continuous}") String outputDirContinuous
     ) {
-        ContinuousAsyncProfilerProperties properties = ContinuousAsyncProfilerProperties.builder()
+        this.properties = ContinuousAsyncProfilerProperties.builder()
                 .enabled(enabled)
                 .event(event)
                 .stopFile(stopFile)
@@ -56,37 +50,10 @@ public class ContinuousAsyncProfilerConfiguration {
                 .archiveOutputDir(outputDirArchive)
                 .profilerLibPath(profilerLibPath)
                 .build();
-
-        log.info("Staring with configuration: {}", properties);
-
-        if (!properties.isEnabled()) {
-            return;
-        }
-
-        createOutputDirectories(properties);
-        AsyncProfiler asyncProfiler = StringUtils.isEmpty(profilerLibPath) ? AsyncProfiler.getInstance() : AsyncProfiler.getInstance(profilerLibPath);
-
-        threads.add(new Thread(new ContinuousAsyncProfilerRunner(asyncProfiler, properties), "cont-prof-runner"));
-        threads.add(new Thread(new ContinuousAsyncProfilerCleaner(properties), "cont-prof-cleaner"));
-        threads.add(new Thread(new ContinuousAsyncProfilerArchiver(properties), "cont-prof-arch"));
-        threads.add(new Thread(new ContinuousAsyncProfilerCompressor(properties), "cont-prof-gzip"));
-        log.info("Starting continuous profiling threads");
-        threads.forEach(Thread::start);
     }
 
-    @PreDestroy
-    void shutdown() {
-        log.info("Spring context destroyed, shutting down threads");
-        threads.forEach(Thread::interrupt);
-    }
-
-    private void createOutputDirectories(ContinuousAsyncProfilerProperties properties) {
-        try {
-            log.debug("Checking if output dirs exist");
-            Files.createDirectories(Paths.get(properties.getArchiveOutputDir()));
-            Files.createDirectories(Paths.get(properties.getContinuousOutputDir()));
-        } catch (IOException e) {
-            throw new IllegalStateException("Cannot create output dirs", e);
-        }
+    @Bean
+    ContinuousAsyncProfiler continuousAsyncProfiler() {
+        return new ContinuousAsyncProfiler(properties);
     }
 }

--- a/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerConfiguration.java
+++ b/continuous-async-profiler/src/main/java/com/github/krzysztofslusarski/asyncprofiler/ContinuousAsyncProfilerConfiguration.java
@@ -27,16 +27,16 @@ public class ContinuousAsyncProfilerConfiguration {
     private final ContinuousAsyncProfilerProperties properties;
 
     public ContinuousAsyncProfilerConfiguration(
-            @Value("${asyncProfiler.continuous.enabled:true}") boolean enabled,
-            @Value("${asyncProfiler.continuous.dumpIntervalSeconds:60}") int dumpIntervalSeconds,
-            @Value("${asyncProfiler.continuous.continuousOutputsMaxAgeHours:24}") int continuousOutputsMaxAgeHours,
-            @Value("${asyncProfiler.continuous.archiveOutputsMaxAgeDays:30}") int archiveOutputsMaxAgeDays,
-            @Value("${asyncProfiler.continuous.archiveCopyRegex:.*_13:0.*}") String archiveCopyRegex,
-            @Value("${asyncProfiler.continuous.event:wall}") String event,
-            @Value("${asyncProfiler.continuous.profilerLibPath:}") String profilerLibPath,
-            @Value("${asyncProfiler.continuous.stopWorkFile:profiler-stop}") String stopFile,
-            @Value("${asyncProfiler.continuous.outputDir.archive:logs/archive}") String outputDirArchive,
-            @Value("${asyncProfiler.continuous.outputDir.continuous:logs/continuous}") String outputDirContinuous
+            @Value("${async-profiler.continuous.enabled:true}") boolean enabled,
+            @Value("${async-profiler.continuous.dump-interval:60}") int dumpIntervalSeconds,
+            @Value("${async-profiler.continuous.continuous-outputs-max-age-hours:24}") int continuousOutputsMaxAgeHours,
+            @Value("${async-profiler.continuous.archive-outputs-max-age-days:30}") int archiveOutputsMaxAgeDays,
+            @Value("${async-profiler.continuous.archive-copy-regex:.*_13:0.*}") String archiveCopyRegex,
+            @Value("${async-profiler.continuous.event:wall}") String event,
+            @Value("${async-profiler.continuous.profiler-lib-path:}") String profilerLibPath,
+            @Value("${async-profiler.continuous.stop-work-file:profiler-stop}") String stopFile,
+            @Value("${async-profiler.continuous.output-dir.archive:logs/archive}") String outputDirArchive,
+            @Value("${async-profiler.continuous.output-dir.continuous:logs/continuous}") String outputDirContinuous
     ) {
         this.properties = ContinuousAsyncProfilerProperties.builder()
                 .enabled(enabled)


### PR DESCRIPTION
Add autocompletion of properties with documentation and info about
default values. It can be extended in future by using custom Converters
or by adding custom validation in JSR-303 format. Properties uses
canonical format (use lowercase kebab-case names). For dump interval
sufix seconds has been removed, as user can set 1m (as 1 minute dump
interval).

Example properties:
async-profiler.continuous.enabled=true
async-profiler.continuous.dump-interval=30s
async-profiler.continuous.continuous-outputs-max-age-hours=48h
async-profiler.continuous.archive-outputs-max-age-days=26d
async-profiler.continuous.archive-copy-regex=.*_14:0.*
async-profiler.continuous.event=cpu
async-profiler.continuous.output-dir.continuous=logs/continous
async-profiler.continuous.output-dir.archive=logs/archive
async-profiler.continuous.stop-work-file=profiles-stop
async-profiler.continuous.profiler-lib-path=lib/libasyncProfiler.so

Moreover there is refactor decoupling spring-framework configuration
using `@Values` from spring-boot configuration using
ConfigurationProperties

The `@PreDestroy` annotation has been replaces with DisposableBean in
order to drop use of `javax.annotation` package which is dropped since
Java 9.